### PR TITLE
Add sowing for petsc@develop

### DIFF
--- a/packages/petsc/package.py
+++ b/packages/petsc/package.py
@@ -12,6 +12,8 @@ class Petsc(OrigPetsc):
     git = "https://github.com/firedrakeproject/petsc.git"
 
     version("develop", branch="firedrake", no_cache=True)
+    # Git repository needs sowing to build Fortran interface
+    depends_on("sowing", when="@develop")
 
     # Desired variants:
     # [Alphabetical]


### PR DESCRIPTION
Git repository needs sowing to build Fortran interface.

Ref: https://github.com/spack/spack/blob/ba0d182e103f2dead098985c671323df6fe04dc2/var/spack/repos/builtin/packages/petsc/package.py#L187