### PR TITLE
Delete the un-necessary patch for petsc4py and slepc4py

### DIFF
--- a/packages/py-petsc4py/package.py
+++ b/packages/py-petsc4py/package.py
@@ -22,8 +22,6 @@ class PyPetsc4py(PythonPackage):
 
     version("develop", branch="firedrake", no_cache=True)
 
-    patch("ldshared-dev.patch")
-
     depends_on("py-cython", type=("build", "run"))
     depends_on("python@2.6:2.8,3.3:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))

--- a/packages/py-slepc4py/package.py
+++ b/packages/py-slepc4py/package.py
@@ -20,8 +20,6 @@ class PySlepc4py(PythonPackage):
 
     version("develop", branch="firedrake", no_cache=True)
 
-    patch("ldshared-dev.patch")
-
     depends_on("py-cython", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))


### PR DESCRIPTION
The patch is not needed, see https://github.com/spack/spack/pull/36588